### PR TITLE
Fix icon sizing in edge

### DIFF
--- a/css/direct_menu.css
+++ b/css/direct_menu.css
@@ -46,8 +46,8 @@
         color: #1d2d44!important;
     }
     #navigation div li .app-icon {
-        max-height: 20px;
-        max-width: 20px;
+        height: 20px;
+        width: 20px;
     }
     .app-loading,
     .icon-loading-dark {


### PR DESCRIPTION
Edge has a bug with sizing svg images when using max-width/height

before:

![](https://i.imgur.com/Pk6jstk.png)

after:

![](https://i.imgur.com/XClH1lo.png)
