### PR TITLE
[FIX] juliushaertl/direct_menu#25

### DIFF
--- a/css/direct_menu.css
+++ b/css/direct_menu.css
@@ -53,9 +53,17 @@
         height: 20px;
         width: 20px;
     }
-    .app-loading,
-    .icon-loading-dark {
-        background-image: none
+    .app-loading {
+        background: url('../../../core/img/loading-dark.gif') no-repeat center center;
+        width: 20px;
+        height: 20px;
+        background-size: 20px;
+    }
+    #navigation .app-loading img {
+        display: none;
+    }
+    #navigation #apps .app-loading .icon-loading-dark {
+        display: none !important;
     }
     #navigation div li span {
         display: none;


### PR DESCRIPTION
Clicking a navigation item will show up the loading icon in the navigation bar (size: 20x20) and it even works with the changes in owncloud/core#23916. But I'm not sure if you want to display the loading icon in the navigation bar at all. ;)
