### PR TITLE
[WIP] Allow reordering of menu icons

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,3 +1,4 @@
 <?php
 
 OCP\Util::addStyle  ( 'direct_menu', 'direct_menu' );
+OCP\Util::addScript  ( 'direct_menu', 'direct_menu' );

--- a/js/direct_menu.js
+++ b/js/direct_menu.js
@@ -1,0 +1,43 @@
+$(function() {
+
+    var app_menu = $('#apps ul');
+
+    if(typeof(Storage) !== "undefined") {
+
+        $( "#apps ul" ).sortable({
+            handle: 'img',
+            axis:'x',
+            stop: function( event, ui ) {
+                var items = []
+                    $("#apps ul").children().each(function(i,el){
+                        var item = $(el).find('a').attr('href');
+                        items.push(item)
+                    })
+
+                var json = JSON.stringify(items);
+                localStorage.setItem("direct_menu-order", json);
+            }
+        });
+
+        var json = localStorage.getItem("direct_menu-order");
+        try {
+            var order = JSON.parse( json ).reverse();
+        } catch (e) {
+            var order = []
+        }
+        if (order.length==0)
+            return;
+
+        available_apps = {};
+        app_menu.find('li').each(function() {
+            var id =  $(this).find('a').attr('href');
+            available_apps[id] = $(this);
+        });
+        $.each(order,function(order,value) {
+            app_menu.prepend(available_apps[value]);
+        })
+
+    } else {
+        console.log("No local storage support, custom menu order will get ignored");
+    }
+});


### PR DESCRIPTION
This commit enables reordering on the apps menu. A users custom order will be
saved inside the browsers local storage.
- [ ] Avoid moving of active app title
- [ ] Apps + button should always be the last icon
- [ ] Add ability to set a default order for new Users
- [ ] Service for storing user and system settings
- [ ] Admin UI to set system order
- [ ] Move from localstorage to user config
