### PR TITLE
Add compitibility to owncloud 9.1(-pre) loading animation

### DIFF
--- a/css/direct_menu.css
+++ b/css/direct_menu.css
@@ -49,7 +49,11 @@
         text-align: center;
         color: #1d2d44!important;
     }
-    #navigation .app-loading img {
+    #navigation .app-icon {
+        width: 20px;
+        height: 20px;
+    }
+    #navigation .app-loading .app-icon {
         display: none;
     }
     #navigation .app-loading .icon-loading-dark {

--- a/css/direct_menu.css
+++ b/css/direct_menu.css
@@ -49,21 +49,22 @@
         text-align: center;
         color: #1d2d44!important;
     }
-    #navigation div li .app-icon {
-        height: 20px;
-        width: 20px;
-    }
-    .app-loading {
-        background: url('../../../core/img/loading-dark.gif') no-repeat center center;
-        width: 20px;
-        height: 20px;
-        background-size: 20px;
-    }
     #navigation .app-loading img {
         display: none;
     }
-    #navigation #apps .app-loading .icon-loading-dark {
-        display: none !important;
+    #navigation .app-loading .icon-loading-dark {
+        background-size: 20px;
+        position: relative;
+        top: 0;
+        left: 0;
+        width: 20px;
+        height: 20px;
+        display: inline-block !important;
+    }
+    #navigation #apps .app-loading .icon-loading-dark::after {
+        width: 18px;
+        height: 18px;
+        margin: -10px 0 0 -10px;
     }
     #navigation div li span {
         display: none;


### PR DESCRIPTION
I have tested owncloud 9.1 nightly and the loading animation is done with css now and do not use an image anymore. So I have added compatibility to the nightly and also tested it on 9.0, which works fine too. I have not tested the changes on older owncloud versions. Tested in Firefox, Vivaldi (Webkit), MS Edge (current versions).
