### PR TITLE
Add a check for inverted theme to fix #34 invisible icons in drawer

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,4 +1,11 @@
 <?php
 
-OCP\Util::addStyle  ( 'direct_menu', 'direct_menu' );
-OCP\Util::addScript ( 'direct_menu', 'direct_menu' );
+$inverted = false;
+
+if(\OCP\App::isEnabled('theming')) {
+   $color = \OC::$server->getThemingDefaults()->getMailHeaderColor();
+   $util = new \OCA\Theming\Util();
+   $inverted = $util->invertTextColor($color);
+}
+
+OCP\Util::addStyle  ( 'direct_menu', ($inverted ? 'direct_menu_inverted' : 'direct_menu') );

--- a/css/direct_menu_inverted.css
+++ b/css/direct_menu_inverted.css
@@ -155,7 +155,5 @@
     #navigation svg image {
       width: 100%;
       height: 100%;
-      -webkit-filter: none;
-      filter: none;
     }
 }

--- a/js/direct_menu.js
+++ b/js/direct_menu.js
@@ -1,9 +1,0 @@
-$( document ).ready(function() {
-  if(OCA.Theming && !OCA.Theming.inverted) {
-    $('#apps svg').each(function(idx) { 
-      var src = $(this).find("image").attr("xlink:href");
-      $(this).parent().prepend("<img src=\""+src+"\" class=\"app-icon svg\"/>");
-      $(this).remove();
-    });
-  }
-});


### PR DESCRIPTION
Check for the theming app and if text color is inverted, to load respective
style sheet. JS hack removed. Tested on Mac for latest Chrome/Firefox/Safari, Win 7 IE11 and Chrome for Android.
- [ ] Test on iOS
- [ ] Test on Microsoft Edge
- [ ] Test on owncloud
