### PR TITLE
adjust contrast between active and inactive apps

### DIFF
--- a/templates/direct_menu.php
+++ b/templates/direct_menu.php
@@ -168,8 +168,8 @@
 
 	#navigation a svg,
 	#navigation a span {
-		-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=90)";
-		opacity: .9;
+		-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+		opacity: .5;
 	}
 
 	#navigation a:hover svg,


### PR DESCRIPTION
Before – unclear which app is exactly selected, and all the icons fight for attention (even against the content):
![capture du 2016-12-17 04-21-26](https://cloud.githubusercontent.com/assets/925062/21284065/782cc8a8-c410-11e6-819f-84e583c7ef30.png)

After – only the relevant app is highlighted:
![capture du 2016-12-17 04-21-54](https://cloud.githubusercontent.com/assets/925062/21284064/782b2e12-c410-11e6-9130-c7506dfe99a3.png)
Using the same 50% vs 100% opacity contrast we use in the current menu, so it’s also consistent with that (which is still shown on smaller sizes).

Please review @juliushaertl @eppfel @skjnldsv :)