### PR TITLE
adjust whitespace and top border radius to match other dropdowns

### DIFF
--- a/templates/direct_menu.php
+++ b/templates/direct_menu.php
@@ -107,7 +107,9 @@
 		-webkit-border-radius: 3px;
 		-moz-border-radius: 3px;
 		border-radius: 3px;
-		margin-top: 3px;
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+		margin-top: 0;
 		border: none;
 		color: #333;
 		left: 50%;


### PR DESCRIPTION
Before:
![capture du 2016-12-17 04-37-33](https://cloud.githubusercontent.com/assets/925062/21284130/ab876530-c412-11e6-89ec-a69aa6c87f68.png)

After:
![capture du 2016-12-17 04-35-34](https://cloud.githubusercontent.com/assets/925062/21284131/ab883b54-c412-11e6-8461-6393deaef3e0.png)

Please review @juliushaertl @eppfel @skjnldsv

Btw we should also adjust the shadows then. Probably use the shadow from here on the other dropdowns because it’s much nicer and softer. @juliushaertl do you want to prepare a PR for core so we have it in one place? :)