### PR TITLE
adjust popover padding and width to fit name of app

### DIFF
--- a/templates/direct_menu.php
+++ b/templates/direct_menu.php
@@ -102,7 +102,9 @@
 	}
 
 	#navigation div li:hover span {
-		background-color: white;
+		width: auto;
+		padding: 8px 12px;
+		background-color: #fff;
 		-webkit-border-radius: 3px;
 		-moz-border-radius: 3px;
 		border-radius: 3px;
@@ -113,7 +115,6 @@
 		color: #333;
 		left: 50%;
 		transform: translateX(-50%);
-		padding: 5px;
 		-webkit-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
 		-moz-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));
 		-ms-filter: drop-shadow(0 0 5px rgba(150, 150, 150, 0.75));


### PR DESCRIPTION
This additionally makes the width of the name popover be dependent on the name of the app so it looks more polished. And the padding was adjusted so it looks nicely balanced on left/right vs top/bottom.

Try it out @juliushaertl @eppfel @skjnldsv