### PR TITLE
Make direct_menu incompatible with Nextcloud 12

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,11 +10,10 @@
     <author>Julius Härtl</author>
     <dependencies>
         <owncloud min-version="9.0" max-version="9.2" />
-        <nextcloud min-version="9" max-version="12" />
+        <nextcloud min-version="9" max-version="11" />
     </dependencies>
     <repository type="git">https://github.com/juliushaertl/direct_menu.git</repository>
     <bugs>https://github.com/juliushaertl/direct_menu/issues</bugs>
     <screenshot>https://bitgrid.net/~jus/direct_menu_nc.png</screenshot>
     <ocsid>169148</ocsid>
 </info>
-


### PR DESCRIPTION
Since https://github.com/nextcloud/server/pull/3008 is merged now, direct_menu is not longer necessary, so we should prevent users from installing/activating this app if they are using Nextcloud 12 😉  

@juliushaertl 

Signed-off-by: Marius Blüm <marius@lineone.io>